### PR TITLE
query for a specific table in a specific schema

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -420,7 +420,7 @@ func (instance *Instance) Schemas(onlyNames ...string) ([]*Schema, error) {
 		}
 		g, ctx := errgroup.WithContext(context.Background())
 		g.Go(func() (err error) {
-			schemas[n].Tables, err = querySchemaTables(ctx, schemaDB, rawSchema.Name, flavor)
+			schemas[n].Tables, err = querySchemaTables(ctx, schemaDB, rawSchema.Name, "", flavor)
 			return err
 		})
 		g.Go(func() (err error) {

--- a/introspect.go
+++ b/introspect.go
@@ -192,8 +192,8 @@ func queryTablesInSchema(ctx context.Context, db *sqlx.DB, schema, explicitTable
 		WHERE  t.table_schema = ?
 		AND    t.table_type = 'BASE TABLE'`
 	if explicitTable != "" {
-		query = query + `
-			AND    t.table_name = ?`
+		query += `
+		AND    t.table_name = ?`
 		args = append(args, explicitTable)
 	}
 	if err := db.SelectContext(ctx, &rawTables, query, args...); err != nil {

--- a/introspect.go
+++ b/introspect.go
@@ -21,8 +21,23 @@ import (
 
 var reExtraOnUpdate = regexp.MustCompile(`(?i)\bon update (current_timestamp(?:\(\d*\))?)`)
 
-func querySchemaTables(ctx context.Context, db *sqlx.DB, schema string, flavor Flavor) ([]*Table, error) {
-	tables, havePartitions, err := queryTablesInSchema(ctx, db, schema, flavor)
+// QuerySchemaTable reads and returns a single, specific table
+func QuerySchemaTable(ctx context.Context, db *sqlx.DB, schema, table string, flavor Flavor) (*Table, error) {
+	if table == "" {
+		return nil, fmt.Errorf("QuerySchemaTable exepects non=empty table name")
+	}
+	tables, err := querySchemaTables(ctx, db, schema, table, flavor)
+	if err != nil {
+		return nil, err
+	}
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	return tables[0], nil
+}
+
+func querySchemaTables(ctx context.Context, db *sqlx.DB, schema, explicitTable string, flavor Flavor) ([]*Table, error) {
+	tables, havePartitions, err := queryTablesInSchema(ctx, db, schema, explicitTable, flavor)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +168,7 @@ func querySchemaTables(ctx context.Context, db *sqlx.DB, schema string, flavor F
 	return tables, nil
 }
 
-func queryTablesInSchema(ctx context.Context, db *sqlx.DB, schema string, flavor Flavor) ([]*Table, bool, error) {
+func queryTablesInSchema(ctx context.Context, db *sqlx.DB, schema, explicitTable string, flavor Flavor) ([]*Table, bool, error) {
 	var rawTables []struct {
 		Name               string         `db:"table_name"`
 		Type               string         `db:"table_type"`
@@ -165,6 +180,7 @@ func queryTablesInSchema(ctx context.Context, db *sqlx.DB, schema string, flavor
 		CharSet            string         `db:"character_set_name"`
 		CollationIsDefault string         `db:"is_default"`
 	}
+	args := []interface{}{schema}
 	query := `
 		SELECT SQL_BUFFER_RESULT
 		       t.table_name AS table_name, t.table_type AS table_type, t.engine AS engine,
@@ -175,7 +191,12 @@ func queryTablesInSchema(ctx context.Context, db *sqlx.DB, schema string, flavor
 		JOIN   information_schema.collations c ON t.table_collation = c.collation_name
 		WHERE  t.table_schema = ?
 		AND    t.table_type = 'BASE TABLE'`
-	if err := db.SelectContext(ctx, &rawTables, query, schema); err != nil {
+	if explicitTable != "" {
+		query = query + `
+			AND    t.table_name = ?`
+		args = append(args, explicitTable)
+	}
+	if err := db.SelectContext(ctx, &rawTables, query, args...); err != nil {
 		return nil, false, fmt.Errorf("Error querying information_schema.tables for schema %s: %s", schema, err)
 	}
 	if len(rawTables) == 0 {


### PR DESCRIPTION
It's now possible to only read a specific single `Table` in a specific schema. The function `QuerySchemaTable` returns a `*Table`, which is `nil` if the table does not exist.