### PR TITLE
forked repo needs to have a different module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/skeema/tengo
+module github.com/planetscale/tengo
 
 go 1.14
 


### PR DESCRIPTION
This is an unfortunate constraint for using this repo in `go.mod`. It is unfortunate because it breaks compatibility (the fork must be careful never to contribute this file upstream)